### PR TITLE
Remove client_id

### DIFF
--- a/Domainr/info.plist
+++ b/Domainr/info.plist
@@ -43,7 +43,7 @@
 				<string>require_once('workflows.php');
 $w = new Workflows();
 $query = urlencode( "{query}" );
-$url = "https://api.domainr.com/v1/search?client_id=alfred_dingyi&q=$query";
+$url = "https://api.domainr.com/v1/search?client_id={your-mashape-key}&q=$query";
 $domains = $w-&gt;request( $url );
 $domains = json_decode( $domains );
 


### PR DESCRIPTION
Due to API abuse, we're locking these down further. Details in our [API documentation](http://domainr.build/docs/authentication).